### PR TITLE
add equality check while comparing dimensions with max values

### DIFF
--- a/src/quill.imageCompressor.js
+++ b/src/quill.imageCompressor.js
@@ -187,7 +187,7 @@ async function downscaleImage(
 }
 
 function getDimensions(inputWidth, inputHeight, maxWidth, maxHeight) {
-  if (inputWidth < maxWidth && inputHeight < maxHeight) {
+  if (inputWidth <= maxWidth && inputHeight <= maxHeight) {
     return [inputWidth, inputHeight];
   }
   if (inputWidth > maxWidth) {


### PR DESCRIPTION
adding a photo which of width is equal to max width,getDimension function yields nothing and gives followin error

`Invalid attempt to destructure non-iterable instance`

thanks for this nice plugin