### PR TITLE
Fix word handling

### DIFF
--- a/src/quill.imageDrop.js
+++ b/src/quill.imageDrop.js
@@ -87,14 +87,13 @@ export class ImageDrop {
 
   getImageFiles(filesList) {
     const files = Array.from(filesList);
-    this.logger.log("readFiles from linked", { files });
+    this.logger.log("readFiles", { files });
     // check each file for an image
     function isFileImage(file) {
       const isImage = !!file.type.match(
         /^image\/(gif|jpe?g|a?png|svg|webp|bmp|vnd\.microsoft\.icon)/i
         );
-        console.log("isImageFile", file.type, isImage);
-        return isImage;
+      return isImage;
     }
     const images = files.filter(isFileImage);
     return images || [];

--- a/src/quill.imageDrop.js
+++ b/src/quill.imageDrop.js
@@ -72,19 +72,29 @@ export class ImageDrop {
     if (images.length === 0) {
       return;
     }
+
+
+    // Text pasted from word will contain both text/html and image/png. 
+    // 
+    if (Array.from(evt.clipboardData.items).some(f => f.type === 'text/html')) {
+      this.logger.log("detected html, not handling");
+      return;
+    }
+
     evt.preventDefault();
     this.handleNewImageFiles(images);
   }
 
   getImageFiles(filesList) {
     const files = Array.from(filesList);
-    this.logger.log("readFiles", { files });
+    this.logger.log("readFiles from linked", { files });
     // check each file for an image
     function isFileImage(file) {
       const isImage = !!file.type.match(
         /^image\/(gif|jpe?g|a?png|svg|webp|bmp|vnd\.microsoft\.icon)/i
-      );
-      return isImage;
+        );
+        console.log("isImageFile", file.type, isImage);
+        return isImage;
     }
     const images = files.filter(isFileImage);
     return images || [];


### PR DESCRIPTION
There's an issue when pasting text from MS Word; one of the clipboard types is `image/png`, which contains a useless black box.   Certainly an issue with Word but is not something they'll likely change at this point. 

So, I added a check for `text/html` in the included types to determine if the paste should be handled.   This may not be the best solution; open to other suggestions.    And feel free not to merge -- this can just be for future documentation, if you prefer.  :)
