### PR TITLE
#19 disable logging for warnings and errors if debug is false

### DIFF
--- a/src/quill.imageCompressor.js
+++ b/src/quill.imageCompressor.js
@@ -50,14 +50,23 @@ const Logger = {
     if (!debug) {
       return (...any) => {};
     }
+
     const boundLogFn = console.log.bind(console, this.prefixString());
     return boundLogFn;
   },
   get error() {
+    if (!debug) {
+      return (...any) => {};
+    }
+
     const boundLogFn = console.error.bind(console, this.prefixString());
     return boundLogFn;
   },
   get warn() {
+    if (!debug) {
+      return (...any) => {};
+    }
+
     const boundLogFn = console.warn.bind(console, this.prefixString());
     return boundLogFn;
   },


### PR DESCRIPTION
Follow up for https://github.com/benwinding/quill-image-compress/issues/19 
If debug is false it will also disable console logging for errors and warnings 