### PR TITLE
Add keepImageTypes and ignoreImageTypes options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # quill-image-compress
 <!-- [START badges] -->
-[![NPM Version](https://img.shields.io/npm/v/quill-image-compress.svg)](https://www.npmjs.com/package/quill-image-compress) 
-[![License](https://img.shields.io/npm/l/quill-image-compress.svg)](https://github.com/benwinding/quill-image-compress/blob/master/LICENSE) 
-[![Downloads/week](https://img.shields.io/npm/dm/quill-image-compress.svg)](https://www.npmjs.com/package/quill-image-compress) 
+[![NPM Version](https://img.shields.io/npm/v/quill-image-compress.svg)](https://www.npmjs.com/package/quill-image-compress)
+[![License](https://img.shields.io/npm/l/quill-image-compress.svg)](https://github.com/benwinding/quill-image-compress/blob/master/LICENSE)
+[![Downloads/week](https://img.shields.io/npm/dm/quill-image-compress.svg)](https://www.npmjs.com/package/quill-image-compress)
 [![Github Issues](https://img.shields.io/github/issues/benwinding/quill-image-compress.svg)](https://github.com/benwinding/quill-image-compress)
 ![Build and Publish](https://github.com/benwinding/quill-image-compress/workflows/Build%20and%20Publish/badge.svg)
 <!-- [END badges] -->
 
-Quill.js Module which compresses images that are uploaded to the editor 
+Quill.js Module which compresses images that are uploaded to the editor
 
 - [Live Demo!](https://benwinding.github.io/quill-image-compress/src/demo.html)
 - [Live Demo! (with script tag)](https://benwinding.github.io/quill-image-compress/src/demo-script-tag.html)
@@ -21,7 +21,7 @@ Quill.js Module which compresses images that are uploaded to the editor
   - Drag/Dropped into quill
   - Pasted into quill
   - Clicked image load button
-- Handles most image formats a browser can read: 
+- Handles most image formats a browser can read:
   - `gif|jpeg|png|svg|webp|bmp|vnd`
 - Compression options [more info](#options)
 
@@ -71,13 +71,21 @@ const quill = new Quill(editor, {
 
 ## Options
 
-- **maxWidth**
+- **[Integer] maxWidth, maxHeight**
   - Maximum width of images (in pixels)
-- **quality** 
+- **[Float] quality**
   - Image quality range: 0.0 - 1.0
-- **imageType**
+- **[String] imageType**
   - Values: 'image/jpeg' , 'image/png' ... etc
-- **debug**
+- **[Array] keepImageTypes**  
+  Preserve image type and apply quality, maxWidth, maxHeight options
+  - Values: ['image/jpeg', 'image/png']
+
+- **[Array] ignoreImageTypes**  
+  Image types contained in this array retain their original images, do not compress them.
+  - Values: ['image'/jpeg', 'image/webp']
+
+- **[Boolean] debug**
   - Displays console logs: true/false
 
 ## Thanks

--- a/src/downscaleImage.js
+++ b/src/downscaleImage.js
@@ -4,10 +4,15 @@ export async function downscaleImage(
   maxWidth,
   maxHeight,
   imageType,
+  keepImageTypes,
+  ignoreImageTypes,
   imageQuality,
   logger,
 ) {
   "use strict";
+  // Input image values
+  const inputImageType = dataUrl.split(';')[0].split(':')[1];
+
   // Provide default values
   imageType = imageType || "image/jpeg";
   imageQuality = imageQuality || 0.7;
@@ -34,6 +39,17 @@ export async function downscaleImage(
 
   // Draw the downscaled image on the canvas and return the new data URL.
   const ctx = canvas.getContext("2d");
+
+  // If the type is included in the ignore list, return the original
+  if (ignoreImageTypes.includes(inputImageType)) {
+    return dataUrl;
+  }
+
+  // If the type is included in keep type list, fix the image type
+  if (keepImageTypes.includes(inputImageType)) {
+    imageType = inputImageType;
+  }
+
   ctx.drawImage(image, 0, 0, newWidth, newHeight);
   const newDataUrl = canvas.toDataURL(imageType, imageQuality);
   logger.log("downscaling image...", {
@@ -42,6 +58,8 @@ export async function downscaleImage(
       maxWidth,
       maxHeight,
       imageType,
+      ignoreImageTypes,
+      keepImageTypes,
       imageQuality,
     },
     newHeight,

--- a/src/quill.imageCompressor.js
+++ b/src/quill.imageCompressor.js
@@ -6,7 +6,7 @@ function warnAboutOptions(options) {
   if (options.maxWidth && typeof options.maxWidth !== "number") {
     Logger.warn(
       `[config error] 'maxWidth' is required to be a "number" (in pixels), 
-recieved: ${options.maxWidth}
+received: ${options.maxWidth}
 -> using default 1000`
     );
     options.maxWidth = 1000;
@@ -14,7 +14,7 @@ recieved: ${options.maxWidth}
   if (options.maxHeight && typeof options.maxHeight !== "number") {
     Logger.warn(
       `[config error] 'maxHeight' is required to be a "number" (in pixels), 
-recieved: ${options.maxHeight}
+received: ${options.maxHeight}
 -> using default 1000`
     );
     options.maxHeight = 1000;
@@ -22,7 +22,7 @@ recieved: ${options.maxHeight}
   if (options.quality && typeof options.quality !== "number") {
     Logger.warn(
       `quill.imageCompressor: [config error] 'quality' is required to be a "number", 
-recieved: ${options.quality}
+received: ${options.quality}
 -> using default 0.7`
     );
     options.quality = 0.7;
@@ -34,10 +34,28 @@ recieved: ${options.quality}
   ) {
     Logger.warn(
       `quill.imageCompressor: [config error] 'imageType' is required be in the form of "image/png" or "image/jpeg" etc ..., 
-recieved: ${options.imageType}
+received: ${options.imageType}
 -> using default image/jpeg`
     );
     options.imageType = "image/jpeg";
+  }
+  if (
+    options.keepImageTypes &&
+    (!Array.isArray(options.keepImageTypes))
+  ) {
+    Logger.warn(
+      `quill.imageCompressor: [config error] 'keepImageTypes' is required to be a "array", received: ${options.keepImageTypes} -> using default []`
+    )
+    options.keepImageTypes = [];
+  }
+  if (
+    options.ignoreImageTypes &&
+    (!Array.isArray(options.ignoreImageTypes))
+  ) {
+    Logger.warn(
+      `quill.imageCompressor: [config error] 'ignoreImageTypes' is required to be a "array", received: ${options.ignoreImageTypes} -> using default []`
+    )
+    options.ignoreImageTypes = [];
   }
 }
 
@@ -132,14 +150,15 @@ class imageCompressor {
   }
 
   async downscaleImageFromUrl(dataUrl) {
-    const logger = Logger;
     const dataUrlCompressed = await downscaleImage(
       dataUrl,
       this.options.maxWidth,
       this.options.maxHeight,
       this.options.imageType,
+      this.options.keepImageTypes,
+      this.options.ignoreImageTypes,
       this.options.quality,
-      logger,
+      Logger,
     );
     Logger.log("downscaleImageFromUrl", { dataUrl, dataUrlCompressed });
     return dataUrlCompressed;


### PR DESCRIPTION
**keepImageTypes**
For images with higher compression than the specified imageType, conversion to the specified format may not be necessary. (ex: when converting images in webp format to jpegs)
In this case, if "image/webp" is registered in ignoreImageTypes, images of webp type will not be converted. However, the specified maxWidth, maxHeight, and quality are applied.

**ignoreImageTypes**
The image format included in this array does not compress or adjust width, height, or quality, and uses the original as it is.