### PR TITLE
add insertIntoEditor override option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ const quill = new Quill(editor, {
       imageType: 'image/jpeg', // default
       debug: true, // default
       suppressErrorLogging: false, // default
+      insertIntoEditor: undefined, // default
     }
   }
 });
@@ -87,9 +88,28 @@ const quill = new Quill(editor, {
   Image types contained in this array retain their original images, do not compress them.
   - Values: ['image'/jpeg', 'image/webp']
 
+- **[Function] insertIntoEditor**
+  Custom function to handle inserting the image. If you wanted to upload the image to a webserver rather than embedding with Base64, you could use this function.
+  - Example function, uploading to a webserver:
+    ```js
+    insertIntoEditor: (imageBase64URL, imageBlob) => {    
+      const formData = new FormData();
+      formData.append("file", imageBlob);
+
+      fetch("/upload", {method: "POST", body: formData})
+        .then(response => response.text())
+        .then(result => {
+          const range = editor.getSelection();
+          editor.insertEmbed(range.index, "image", `${result}`, "user");
+        })
+        .catch(error => {
+          console.error(error);
+        });
+    }
+    ```
+
 - **[Boolean] debug**
   - Displays console logs: true/false
 
 ## Thanks
 This project is based on [quill-image-uploader](https://github.com/NoelOConnell/quill-image-uploader), thanks mate!
-

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
 		"reduce"
 	],
 	"dependencies": {
-    "quill": "^1.x"
-  },
+		"quill": "^1.3.7"
+	},
 	"devDependencies": {
 		"@babel/core": "^7.8.7",
 		"@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -45,8 +45,8 @@
 		"ts-loader": "^8.0.11",
 		"typescript": "^4.1.2",
 		"uglifyjs-webpack-plugin": "^1.1.6",
-		"webpack": "^4.42.0",
-		"webpack-cli": "^3.2.1",
+		"webpack": "^4.46.0",
+		"webpack-cli": "^3.3.12",
 		"webpack-dev-server": "^3.1.14"
 	}
 }

--- a/src/options.object.ts
+++ b/src/options.object.ts
@@ -9,4 +9,5 @@ export type OptionsObject = {
   keepImageTypes?: string[];
   ignoreImageTypes?: string[];
   quality?: number;
+  insertIntoEditor?: (base64URL: string, imageBlob: Blob) => void;
 };

--- a/src/options.validation.ts
+++ b/src/options.validation.ts
@@ -66,4 +66,10 @@ received: ${options.imageType}
     )
     options.ignoreImageTypes = [];
   }
+  if (options.insertIntoEditor && typeof options.insertIntoEditor !== "function") {
+    Logger.warn(
+      `quill.imageCompressor: [config error] 'insertIntoEditor' is required to be a "function", received: ${options.insertIntoEditor} -> using default undefined`
+    )
+    options.insertIntoEditor = undefined;
+  }
 }


### PR DESCRIPTION
Override the `insertIntoEditor` function to handle custom functionality, like uploading the compressed image to a webserver etc. Documented in `README.md`