### PR TITLE
Add editor param to insertIntoEditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const quill = new Quill(editor, {
   Custom function to handle inserting the image. If you wanted to upload the image to a webserver rather than embedding with Base64, you could use this function.
   - Example function, uploading to a webserver:
     ```js
-    insertIntoEditor: (imageBase64URL, imageBlob) => {    
+    insertIntoEditor: (imageBase64URL, imageBlob, editor) => {    
       const formData = new FormData();
       formData.append("file", imageBlob);
 

--- a/src/options.object.ts
+++ b/src/options.object.ts
@@ -9,5 +9,5 @@ export type OptionsObject = {
   keepImageTypes?: string[];
   ignoreImageTypes?: string[];
   quality?: number;
-  insertIntoEditor?: (base64URL: string, imageBlob: Blob) => void;
+  insertIntoEditor?: (base64URL: string, imageBlob: Blob, editor: Quill) => void;
 };

--- a/src/quill.imageCompressor.ts
+++ b/src/quill.imageCompressor.ts
@@ -102,7 +102,7 @@ class imageCompressor {
 
   insertToEditor(url: string, blob: Blob) {
     if (this.options.insertIntoEditor) {
-      this.options.insertIntoEditor(url, blob);
+      this.options.insertIntoEditor(url, blob, this.quill);
     } else {
       this.Logger.log('insertToEditor', {url});
       this.range = this.quill.getSelection();


### PR DESCRIPTION
The current signature of insertIntoEditor makes it hard to use with React. This solves the issue by passing the editor as param, like quill does already for calls like onChange