### PR TITLE
Fixed drop event duplicating local content.

### DIFF
--- a/src/quill.imageDrop.ts
+++ b/src/quill.imageDrop.ts
@@ -7,12 +7,16 @@ import { file2b64 } from "./file2b64";
 From: https://github.com/kensnyder/quill-image-drop-module/blob/master/index.js
 */
 export class ImageDrop {
+  localDrag: boolean = false;
+
   constructor(
     private quill: Quill,
     private onNewDataUrl: (dataUrl: string) => void,
     private logger: ConsoleLogger,
   ) {
     // listen for drop and paste events
+    this.quill.root.addEventListener("dragstart", (e) => this.handleDragStart(e), false);
+    this.quill.root.addEventListener("dragend", (e) => this.handleDragEnd(e), false);
     this.quill.root.addEventListener("drop", (e) => this.handleDrop(e), false);
     this.quill.root.addEventListener(
       "paste",
@@ -21,7 +25,17 @@ export class ImageDrop {
     );
   }
 
+  private handleDragStart(evt: DragEvent) {
+    this.localDrag = true;
+  }
+
+  private handleDragEnd(evt: DragEvent) {
+    this.localDrag = false;
+  }
+
   private async handleDrop(evt: DragEvent) {
+    if (this.localDrag)
+      return; // use default method
     evt.preventDefault();
     if (document.caretRangeFromPoint) {
       const selection = document.getSelection();


### PR DESCRIPTION
If content is dropped into the editor from an external window, everything works but when done so from local content, images are duplicated and text will not move.

This commit forces the browser to perform its default action when actioning local content (and also skipping unnecessary compression on an already compressed item).

Tested on Edge 113.0.1774.50

See [Issue 42](https://github.com/benwinding/quill-image-compress/issues/42) for further information on the bug.