### PR TITLE
Fixing handling when pasted mutliple  file types 

### DIFF
--- a/src/quill.imageDrop.ts
+++ b/src/quill.imageDrop.ts
@@ -76,8 +76,8 @@ export class ImageDrop {
       return;
     }
     // Text pasted from word will contain both text/html and image/png.
-    const imagesNoHtml = images.filter(f => f.type !== 'text/html');
-    if (!imagesNoHtml.length) {
+    const filesHasHtml = images.some(f => f.type === 'text/html');
+    if (filesHasHtml) {
       this.logger.log("handlePaste also detected html");
       return;
     }


### PR DESCRIPTION
New Microsoft Products also paste multiple Data transfer items, like:
![grafik](https://github.com/benwinding/quill-image-compress/assets/18309339/08e32b67-58d0-4cf3-b3ea-e3e615a6a127)

This PR  fixes this.