### PR TITLE
Fixes double handling issue (Issue #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Quill.js Module which compresses images that are uploaded to the editor
 - Compression options [more info](#options)
 - Add multiple images in one drag/paste
 
-_NOTE: :exclamation:you don't need `quill-image-drop-module`, it's included in this package:exclamation:_
+_NOTE: :exclamation: you don't need `quill-image-drop-module`, it's included in this package :exclamation:_
 
 ## Quickstart
 
@@ -57,7 +57,7 @@ const quill = new Quill(editor, {
 ## Quickstart (script tag)
 
 ``` html
-    <script src="https://unpkg.com/quill-image-compress@1.2.11/dist/quill.imageCompressor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/quill-image-compress@2.0/dist/quill.imageCompressor.min.js"></script>
     <script>
       Quill.register("modules/imageCompressor", imageCompressor);
       

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "quill-image-compress",
 	"description": "A Quill rich text editor Module which compresses images uploaded to the editor",
-	"version": "2.0.1",
+	"version": "2.0.3",
 	"main": "dist/quill.imageCompressor.min.js",
 	"types": "types/index.d.ts",
 	"homepage": "https://benwinding.github.io/quill-image-compress/src/demo.html",


### PR DESCRIPTION
When drag/drop or copy/paste from file system, the image is added twice to the editor - one original, one compressed. This was the behaviour originally reported in #51 

It's replicated in the [code pen here](https://codepen.io/enzedonline/pen/gONrmBX?editors=0011).

Oddly doesn't occur when running in the dev server.

Updated `ImageDrop` so that drop and paste event listeners are registered with `useCapture=true`, `event.stopPropgation` called to stop event bubbling in the following places:
- `handleDrop` if image files found
- `handleDrop` if dataTransfer items found
- `handleDataTransferList` if image files found

Tested and [confirmed](https://github.com/benwinding/quill-image-compress/issues/51#issuecomment-2241472766) on Windows. Probably needs double checking on Mac (and Linux??) - sorry, no access to either myself.

Also:
- updated version in package.json -> 2.0.3
- updated script tag url in readme & fixed exclamation not rendering